### PR TITLE
Make biomarkers schema more stringent

### DIFF
--- a/opentargets.json
+++ b/opentargets.json
@@ -1149,10 +1149,11 @@
               "id": {
                 "$ref": "#/definitions/variantId"
               },
-              "variantFunctionalConsequenceId": {
+              "functionalConsequenceId": {
                 "$ref": "#/definitions/variantFunctionalConsequenceId"
               }
             },
+            "required": ["name"],
             "additionalProperties": false
           },
           "uniqueItems": true
@@ -1178,6 +1179,7 @@
                 ]
               }
             },
+            "required": ["name"],
             "additionalProperties": false
           },
           "uniqueItems": true


### PR DESCRIPTION
I have reviewed the upcoming cancer biomarkers data to verify which fields can be nullified and which are required. By doing that, I've made the schema for this data source more stringent.

These are the required fields that must be present in a biomarkers evidence string:
```
      "required": [
        "biomarkerName",
        "confidence",
        "datasourceId",
        "diseaseFromSource",
        "drugFromSource",
        "drugResponse",
        "targetFromSourceId"
      ],
```

I remember when we were designing the new version of the schema, it was rather a feature to make it flexible with fewer required fields. Do you see a problem in making it more rigid? We would be catching more unwanted situations.