### PR TITLE
feat: adding id field to annotation object in pharmacogenomics

### DIFF
--- a/pydantic_models/pharmacogenomics.py
+++ b/pydantic_models/pharmacogenomics.py
@@ -55,6 +55,9 @@ class VariantAnnotation(BaseModel):
     entity: Optional[str] = Field(
         description="Entity affected by the effect.", examples=["malignant hyperthermia"]
     )
+    id: Optional[str] = Field(
+        description="PharmGKB identification of the annotation of the variant effect", examples=["827552123"]
+    )
 
 class EvidenceLevel(str, Enum):
     """Evidence levels class describing the confidence in the assocations."""

--- a/schemas/pharmacogenomics.json
+++ b/schemas/pharmacogenomics.json
@@ -297,6 +297,14 @@
             "malignant hyperthermia"
           ],
           "type": "string"
+        },
+        "id": {
+          "title": "Id",
+          "description": "PharmGKB identification of the annotation of the variant effect",
+          "examples": [
+            "827552123"
+          ],
+          "type": "string"
         }
       }
     }


### PR DESCRIPTION
## Context

Following up discussion on 15th July. See details [in meeting minutes](https://docs.google.com/document/d/13idmiHAHU3cZjW8RFsmQZX-L6oPRThLv_iPfFeXOyJM/edit?tab=t.0#heading=h.pyi0256nhgtv) and [EVA documentation](https://github.com/EBIvariation/opentargets-pharmgkb/issues/60), their [PR](https://github.com/EBIvariation/opentargets-pharmgkb/pull/62)

## Details

- The `VariantAnnotation` object in pgx schema is enriched with PharmGKB annotation identifier
- Pydantic model is updated
- JSON schema is generated based on the models
